### PR TITLE
Add a new workflow to trigger GitHub cache refresh

### DIFF
--- a/.github/scripts/cache.sh
+++ b/.github/scripts/cache.sh
@@ -1,0 +1,19 @@
+#!/bin/sh -l
+
+set -eu
+
+# Requires REPO_ROOT, BOT_TOKEN to be included by workflow
+export GITHUB_API_TOKEN=$BOT_TOKEN
+
+ACT_LOG_PATH=_visualize/LAST_MASTER_UPDATE.txt
+ACT_INPUT_PATH=_visualize
+ACT_DATA_PATH=visualize/github-data
+
+DATA_TIMESTAMP=$(date -u "+%F-%H")
+
+cd $REPO_ROOT/_visualize/scripts
+
+# Run CACHE script
+./CACHE.sh
+
+exit 0

--- a/.github/scripts/update.sh
+++ b/.github/scripts/update.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-# Requires BOT_USER, BOT_TOKEN to be included by workflow
+# Requires REPO_ROOT, BOT_USER, BOT_TOKEN to be included by workflow
 export GITHUB_API_TOKEN=$BOT_TOKEN
 
 ACT_LOG_PATH=_visualize/LAST_MASTER_UPDATE.txt
@@ -14,9 +14,6 @@ DATA_TIMESTAMP=$(date -u "+%F-%H")
 # Configure git
 git config --global user.name "${BOT_USER}"
 git config --global user.email "${BOT_USER}@users.noreply.github.com"
-
-cd datarepo
-REPO_ROOT=$(pwd)
 
 # Store previous END timestamp
 OLD_END=$(cat $ACT_LOG_PATH | grep END | cut -f 2)

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -1,0 +1,44 @@
+name: Scheduled Cache Request
+
+on:
+  schedule:
+    - cron: "45 4 * * *"
+
+jobs:
+  runDataUpdate:
+    name: Run Cache Request
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          path: main
+      - name: Checkout secondary repo
+        uses: actions/checkout@v4
+        with:
+          repository: LLNL/llnl.github.io.git
+          ref: main
+          path: datarepo
+          token: ${{ secrets.BOT_TOKEN }}
+      - name: Setup python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+          cache: "pip"
+          cache-dependency-path: "datarepo/_visualize/scripts/requirements.txt"
+      - name: Install dependencies
+        run: pip install -r datarepo/_visualize/scripts/requirements.txt
+      - name: Run cache script
+        shell: bash
+        run: ./main/.github/scripts/cache.sh
+        env:
+          REPO_ROOT: datarepo
+          BOT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Save log files
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: logfiles
+          path: |
+            datarepo/_visualize/LAST_CACHE_REQUEST.txt
+            datarepo/_visualize/LAST_CACHE_REQUEST.log

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -33,7 +33,7 @@ jobs:
         run: ./main/.github/scripts/cache.sh
         env:
           REPO_ROOT: datarepo
-          BOT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
       - name: Save log files
         if: always()
         uses: actions/upload-artifact@v3

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -2,7 +2,7 @@ name: Scheduled Data Update
 
 on:
   schedule:
-    - cron: "5 8 * * *"
+    - cron: "45 7 * * *"
 
 jobs:
   runDataUpdate:
@@ -32,6 +32,7 @@ jobs:
         shell: bash
         run: ./main/.github/scripts/update.sh
         env:
+          REPO_ROOT: datarepo
           BOT_USER: lc-bot
           BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
       - name: Save log files

--- a/README.md
+++ b/README.md
@@ -5,28 +5,11 @@ This repository runs regular data updates for the [LLNL Software Portal](https:/
 These updates utilize scripts from the [LLNL/llnl.github.io](https://github.com/LLNL/llnl.github.io) repository.
 The new data is pushed back to the same repository.
 
-## Data Update Status
+## Workflow Status
 
-[![Scheduled Date Update][workflow img]][workflow url]
-[![Trigger][schedule img]][schedule url]
-[![Last Update][timestamp img]][timestamp url]
+[![Scheduled Cache Request](https://github.com/lc-bot/llnl.github.io-actions/actions/workflows/cache.yml/badge.svg)](https://github.com/lc-bot/llnl.github.io-actions/actions/workflows/cache.yml)
+[![Scheduled Data Update](https://github.com/lc-bot/llnl.github.io-actions/actions/workflows/update.yml/badge.svg)](https://github.com/lc-bot/llnl.github.io-actions/actions/workflows/update.yml)
 
 ## Portal Status
 
-[![Pages Deployment][deployment img]][deployment url]
-[![Last Deployment][deploytime img]][deployment url]
-
-<!-- "Scheduled Data Update" action status -->
-[workflow img]: https://img.shields.io/github/actions/workflow/status/lc-bot/llnl.github.io-actions/main.yml?branch=main&label=Scheduled%20Data%20Update&logo=github-actions&logoColor=white&style=flat
-[workflow url]: https://github.com/lc-bot/llnl.github.io-actions/actions/workflows/main.yml "lc-bot/llnl.github.io-actions/actions > Scheduled Data Update"
-<!-- "Trigger" schedule -->
-[schedule img]: https://img.shields.io/badge/Trigger-daily%20%40%2008%3A05%20UTC-informational?style=flat
-[schedule url]: https://github.com/lc-bot/llnl.github.io-actions/blob/main/.github/workflows/main.yml "lc-bot/llnl.github.io-actions/.github/workflows/main.yml"
-<!-- "Last Update" timestamp -->
-[timestamp img]: https://img.shields.io/badge/dynamic/json?color=informational&label=Last%20Update&query=%24%5B0%5D.commit.author.date&url=https%3A%2F%2Fapi.github.com%2Frepos%2FLLNL%2Fllnl.github.io%2Fcommits%3Fpath%3D_visualize%2FLAST_MASTER_UPDATE.txt%26per_page%3D1&style=flat
-[timestamp url]: https://github.com/LLNL/llnl.github.io/blob/main/_visualize/LAST_MASTER_UPDATE.txt "LLNL/llnl.github.io/.../LAST_MASTER_UPDATE.txt"
-<!-- "Pages Deployment" status -->
-[deployment img]: https://img.shields.io/github/deployments/LLNL/llnl.github.io/github-pages?label=Pages%20Deployment&logo=github&logoColor=white&style=flat
-[deployment url]: https://github.com/LLNL/llnl.github.io/deployments/github-pages "LLNL/llnl.github.io/deployments/github-pages"
-<!-- "Last Deployment" timestamp -->
-[deploytime img]: https://img.shields.io/badge/dynamic/json?label=Last%20Deployment&query=%24%5B0%5D.updated_at&url=https%3A%2F%2Fapi.github.com%2Frepos%2FLLNL%2Fllnl.github.io%2Fdeployments%3Fenvironment%3Dgithub-pages%26per_page%3D1&style=flat
+[![pages-build-deployment](https://github.com/LLNL/llnl.github.io/actions/workflows/pages/pages-build-deployment/badge.svg)](https://github.com/LLNL/llnl.github.io/actions/workflows/pages/pages-build-deployment)


### PR DESCRIPTION
Will cause GitHub to cache data ahead of main data collection, minimizing query wait times.
Depends on [LLNL/llnl.github.io/pull/642](https://github.com/LLNL/llnl.github.io/pull/642)